### PR TITLE
change: update vrs submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "submodules/vrs"]
 	path = submodules/vrs
 	url = https://github.com/ga4gh/vrs.git
+	branch = metaschema-update

--- a/.requirements.txt
+++ b/.requirements.txt
@@ -2,5 +2,5 @@ pytest
 sphinx==3.5.4
 sphinx-rtd-theme
 ga4gh.gks.metaschema==0.2.0rc3
-python-jsonschema-objects>=0.3,<=0.3.10
+python-jsonschema-objects>=0.3.13
 jsonschema==3.2.0

--- a/schema/merged.json
+++ b/schema/merged.json
@@ -1324,13 +1324,14 @@
             "relative_copy_class": {
                "type": "string",
                "enum": [
-                  "complete loss",
-                  "partial loss",
-                  "copy neutral",
-                  "low-level gain",
-                  "high-level gain"
+                  "EFO:0030070",
+                  "EFO:0030072",
+                  "EFO:0030071",
+                  "EFO:0030067",
+                  "EFO:0030069",
+                  "EFO:0030068"
                ],
-               "description": "MUST be one of \"complete loss\", \"partial loss\", \"copy neutral\", \"low-level gain\" or \"high-level gain\"."
+               "description": "MUST be one of \"EFO:0030070\", \"EFO:0030072\", \"EFO:0030071\", \"EFO:0030067\", \"EFO:0030069\", or \"EFO:0030068\"."
             }
          },
          "required": [

--- a/schema/merged.yaml
+++ b/schema/merged.yaml
@@ -998,13 +998,14 @@ definitions:
       relative_copy_class:
         type: string
         enum:
-        - complete loss
-        - partial loss
-        - copy neutral
-        - low-level gain
-        - high-level gain
-        description: MUST be one of "complete loss", "partial loss", "copy neutral",
-          "low-level gain" or "high-level gain".
+        - EFO:0030070
+        - EFO:0030072
+        - EFO:0030071
+        - EFO:0030067
+        - EFO:0030069
+        - EFO:0030068
+        description: MUST be one of "EFO:0030070", "EFO:0030072", "EFO:0030071", "EFO:0030067",
+          "EFO:0030069", or "EFO:0030068".
     required:
     - location
     - relative_copy_class


### PR DESCRIPTION
- relative_copy_class is now enum for EFO IDs
- update vrs submodule to pull from metaschema branch
- update python-jsonschema-objects version